### PR TITLE
allow customize sitemapsParser gzip contentType

### DIFF
--- a/lib/handlers/sitemapsParser.js
+++ b/lib/handlers/sitemapsParser.js
@@ -31,12 +31,17 @@ module.exports = function (opts) {
     };
   }
 
+  if (typeof opts.gzipContentTypes === "string" && opts.gzipContentTypes.length) {
+    opts.gzipContentTypes = [opts.gzipContentTypes];
+  } else if (!Array.isArray(opts.gzipContentTypes) || !opts.gzipContentTypes.length) {
+    opts.gzipContentTypes = ["application/x-gzip", "application/gzip"];
+  }
+
   return function (context) {
     var xmlBufProm;
 
     // If sitemap has come in compressed state, we must uncompress it!
-    if (context.contentType === "application/x-gzip" ||
-        context.contentType === "application/gzip") {
+    if (opts.gzipContentTypes.indexOf(context.contentType) > -1) {
       xmlBufProm = Promise.promisify(zlib.gunzip)(context.body);
     } else {
       xmlBufProm = Promise.resolve(context.body);


### PR DESCRIPTION
use ```gzipContentTypes``` to customize gzip contentType of sitemaps
example:
```
crawler.addHandler(supercrawler.handlers.sitemapsParser({gzipContentTypes: ["application/x-gzip", "application/gzip", "application/octet-stream"]}));
```