### PR TITLE
Assume robots are allowed if robots.txt returns 410 (Gone)

### DIFF
--- a/lib/Crawler.js
+++ b/lib/Crawler.js
@@ -411,8 +411,8 @@ Crawler.prototype._getOrDownloadRobots = function (url) {
   }).catch(error.HttpError, function (err) {
     var robotsStatusCode = err.statusCode;
 
-    // if robots returns a 404, we assume there are no restrictions.
-    if (robotsStatusCode === 404) {
+    // if robots returns a 404 or 410, we assume there are no restrictions.
+    if (robotsStatusCode === 404 || robotsStatusCode === 410) {
       return Promise.resolve({
         statusCode: 200,
         body: ""

--- a/test/Crawler.spec.js
+++ b/test/Crawler.spec.js
@@ -447,6 +447,21 @@ describe("Crawler", function () {
       }, 200);
     });
 
+    it("crawls all pages if robots.txt is 410", function (done) {
+      var crawler = new Crawler({
+        interval: 10
+      });
+
+      crawler.start();
+      robotsStatusCode = 410;
+
+      setTimeout(function () {
+        crawler.stop();
+        expect(numCrawlsOfUrl("https://example.com/index17.html", false)).to.equal(1);
+        done();
+      }, 200);
+    });
+
     it("excludes all pages if robots.txt could not be crawled", function (done) {
       var crawler = new Crawler({
         interval: 10


### PR DESCRIPTION
While using supercrawler, I noticed that some sites (e.g. http://zompist.com) return a 410 status for their robots.txt. Google indexes that page, so I think supercrawler should be able to crawl it as well.
