### PR TITLE
Parse area href for link

### DIFF
--- a/lib/handlers/htmlLinkParser.js
+++ b/lib/handlers/htmlLinkParser.js
@@ -12,7 +12,7 @@ module.exports = function (opts) {
     $ = context.$ || cheerio.load(context.body);
     context.$ = $;
 
-    return $("a[href], link[href][rel=alternate]").map(function () {
+    return $("a[href], link[href][rel=alternate], area[href]").map(function () {
       var $this,
           targetHref,
           absoluteTargetUrl,


### PR DESCRIPTION
Missing valid tag that may have an `href`.

ref: https://www.w3schools.com/tags/att_href.asp