### PR TITLE
Handle 500 for robots txt

### DIFF
--- a/lib/Crawler.js
+++ b/lib/Crawler.js
@@ -450,12 +450,16 @@ Crawler.prototype._getOrDownloadRobots = function (url) {
   }).catch(error.HttpError, function (err) {
     var robotsStatusCode = err.statusCode;
 
-    // if robots returns a 404 or 410, we assume there are no restrictions.
-    if (robotsStatusCode === 404 || robotsStatusCode === 410) {
-      return Promise.resolve({
-        statusCode: 200,
-        body: ""
-      });
+    // if robots returns a dismissable status code, we assume 
+    // there are no restrictions.
+    switch (robotsStatusCode) {
+        case 404:
+        case 410:
+        case 500:
+            return Promise.resolve({
+                statusCode: 200,
+                body: ""
+            });
     }
 
     // but if there is another status code, we stop crawling the entire website


### PR DESCRIPTION
Ignore the `robots.txt` if there is a server error when retrieving it.