### PR TITLE
Recognize "example.com" (no slash) and "example.com/" (with slash) as the same URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
   - "node"
-  - "6"
+  - "10"
+  - "8"

--- a/lib/Url.js
+++ b/lib/Url.js
@@ -1,3 +1,7 @@
+if (!URL) {
+  var URL = require("url").URL;
+}
+
 var Url;
 
 /**
@@ -18,7 +22,7 @@ Url = function (opts) {
     };
   }
 
-  this._url = opts.url;
+  this._url = new URL(opts.url).href;
   this._statusCode = opts.statusCode ? opts.statusCode : null;
   this._errorCode = opts.errorCode ? opts.errorCode : null;
   this._errorMessage = opts.errorMessage ? opts.errorMessage : null;

--- a/test/Crawler.spec.js
+++ b/test/Crawler.spec.js
@@ -452,7 +452,7 @@ describe("Crawler", function () {
         crawler.stop();
         sinon.assert.calledWith(spy, "https://example.com/index18.html");
         done();
-      }, 200);
+      }, 500);
     });
 
     it("emits a crawled event", function (done) {

--- a/test/FifoUrlList.spec.js
+++ b/test/FifoUrlList.spec.js
@@ -1,4 +1,5 @@
 var FifoUrlList = require("../lib/FifoUrlList"),
+    Url = require("../lib/Url"),
     expect = require("chai").expect,
     makeUrl = require("./utils/makeUrl");
 
@@ -82,6 +83,26 @@ describe("FifoUrlList", function () {
       expect(res.getStatusCode()).to.equal(null);
       done();
     });
+  });
+
+  it("recognizes https://example.com (no slash) and https://example.com/ (with slash) as the same URL", async function () {
+    var fifoUrlList = new FifoUrlList(),
+        url1 = new Url("https://example.com"),
+        url2 = new Url("https://example.com/");
+
+    await fifoUrlList.insertIfNotExists(url1);
+    await fifoUrlList.insertIfNotExists(url2);
+
+    var res1 = await fifoUrlList.getNextUrl();
+    expect(res1.getUrl()).to.equal("https://example.com/");
+    expect(res1.getUniqueId()).to.equal("https://example.com/");
+
+    try {
+      await fifoUrlList.getNextUrl();
+    } catch (err) {
+      expect(err).to.be.an.instanceof(RangeError);
+      expect(err.message).to.equal("The list has been exhausted.");
+    }
   });
 
   describe("upsert", function () {

--- a/test/Url.spec.js
+++ b/test/Url.spec.js
@@ -18,6 +18,10 @@ describe("Url", function () {
     expect(new Url("https://example.com/").getUniqueId()).to.equal("https://example.com/");
   });
 
+  it("adds trailing slash for normalization if the URL of the root page is given (e.g. https://example.com -> https://example.com/)", function () {
+    expect(new Url("https://example.com").getUniqueId()).to.equal("https://example.com/");
+  });
+
   describe("#getStatusCode", function () {
     it("returns the statusCode if specified", function () {
       expect(new Url({
@@ -37,6 +41,12 @@ describe("Url", function () {
     it("returns the URL", function () {
       expect(new Url({
         url: "https://example.com/"
+      }).getUrl()).to.equal("https://example.com/");
+    });
+
+    it("adds trailing slash for normalization if the URL of the root page is given (e.g. https://example.com -> https://example.com/)", function () {
+      expect(new Url({
+        url: "https://example.com"
       }).getUrl()).to.equal("https://example.com/");
     });
   });

--- a/test/Url.spec.js
+++ b/test/Url.spec.js
@@ -4,31 +4,31 @@ var Url = require("../lib/Url"),
 describe("Url", function () {
   it("returns an instance when called as a function", function () {
     expect(Url({
-      url: "https://example.com"
+      url: "https://example.com/"
     })).to.be.an.instanceOf(Url);
   });
 
   it("uses URL as the unique ID", function () {
     expect(new Url({
-      url: "https://example.com"
-    }).getUniqueId()).to.equal("https://example.com");
+      url: "https://example.com/"
+    }).getUniqueId()).to.equal("https://example.com/"); 
   });
 
   it("accepts a string URL as the only argument", function () {
-    expect(new Url("https://example.com").getUniqueId()).to.equal("https://example.com");
+    expect(new Url("https://example.com/").getUniqueId()).to.equal("https://example.com/");
   });
 
   describe("#getStatusCode", function () {
     it("returns the statusCode if specified", function () {
       expect(new Url({
-        url: "https://example.com",
+        url: "https://example.com/",
         statusCode: 201
       }).getStatusCode()).to.equal(201);
     });
 
     it("defaults to null if statusCode not specified", function () {
       expect(new Url({
-        url: "https://example.com"
+        url: "https://example.com/"
       }).getStatusCode()).to.equal(null);
     });
   });
@@ -36,15 +36,15 @@ describe("Url", function () {
   describe("#getUrl", function () {
     it("returns the URL", function () {
       expect(new Url({
-        url: "https://example.com"
-      }).getUrl()).to.equal("https://example.com");
+        url: "https://example.com/"
+      }).getUrl()).to.equal("https://example.com/");
     });
   });
 
   describe("#getErrorCode", function () {
     it("returns the error code", function () {
       expect(new Url({
-        url: "https://example.com",
+        url: "https://example.com/",
         errorCode: "ROBOTS_NOT_ALLOWED"
       }).getErrorCode()).to.equal("ROBOTS_NOT_ALLOWED");
     });
@@ -53,7 +53,7 @@ describe("Url", function () {
   describe("#getErrorMessage", function () {
     it("returns the error message", function () {
       expect(new Url({
-        url: "https://example.com",
+        url: "https://example.com/",
         errorCode: "ROBOTS_NOT_ALLOWED",
         errorMessage: "A robots.txt error"
       }).getErrorMessage()).to.equal("A robots.txt error");
@@ -61,7 +61,7 @@ describe("Url", function () {
 
     it("returns null if no rror message", function () {
       expect(new Url({
-        url: "https://example.com",
+        url: "https://example.com/",
         errorCode: "ROBOTS_NOT_ALLOWED"
       }).getErrorMessage()).to.equal(null);
     });


### PR DESCRIPTION
Currently, https://example.com and https://example.com/ are recognized as different URLs.
Therefore, with the following code, two URLs https://example.com and https://example.com/ are crawled although they are the same page.

```javascript
const urlList = this.crawler.getUrlList();
await urlList.insertIfNotExists(new Url("https://example.com"));
await urlList.insertIfNotExists(new Url("https://example.com/"));
```

In this PR, "https://example.com" is normalized as "https://example.com/" when `Url` object is instantiated so that `UrlList.insertIfNotExists()` doesn't add duplicate URLs.

I removed deprecated Node.js 6 support to use `async` and `await`, but if Node.js 6 should be kept supported, I will rewrite the code using `Promise`.