### PR TITLE
Use Symbol based operator in where clause

### DIFF
--- a/lib/DbUrlList.js
+++ b/lib/DbUrlList.js
@@ -2,6 +2,7 @@ var DbUrlList,
     Promise = require("bluebird"),
     Url = require("./Url"),
     Sequelize = require('sequelize'),
+    { Op } = require('sequelize'),
     crypto = require("crypto"),
     YEAR_MS = 31536000000;
 
@@ -259,7 +260,7 @@ DbUrlList.prototype.getNextUrl = function () {
     return urlTable.findOne({
       where: {
         nextRetryDate: {
-          $lt: new Date()
+          [Op.lt]: new Date()
         }
       },
       order: ["nextRetryDate"]


### PR DESCRIPTION
Edit: https://github.com/brendonboshell/supercrawler/pull/35 already suggests the same change, no idea how I could overlook that...

Supercrawler: 1.7.1
Sequelize: 5.16.0
Node: v12.10.0

Supercrawler uses the "string based operator" `$lt` for a date comparison when it chooses which URL to crawl next.

Sequelize says:

String based operators are deprecated. Please use Symbol based operators for better security, read more at https://sequelize.org/master/manual/querying.html#operators

Because of this, I could not get supercrawler to crawl any URLs when using DbUrlList. The FIFO queue worked fine.

A workaround for me is to setup supercrawler like this:

```js
const supercrawler = require("supercrawler")
const { Op } = require("sequelize")
```
And then set the crawler options like this:
```js
const crawlerOptions = {
  urlList: new supercrawler.DbUrlList({
    db: {
      database: "crawler",
      sequelizeOpts: {
        dialect: "sqlite",
        storage: "crawler.sqlite",
        operatorsAliases: { $lt: Op.lt },
      },
    },
  }),
}
```