### PR TITLE
Allow userAgent option to be a function

### DIFF
--- a/lib/Crawler.js
+++ b/lib/Crawler.js
@@ -82,7 +82,11 @@ Crawler.prototype.getConcurrentRequestsLimit = function () {
  *
  * @return {string} User agent
  */
-Crawler.prototype.getUserAgent = function () {
+Crawler.prototype.getUserAgent = function (url) {
+  if (typeof this._userAgent === 'function') {
+    return this._userAgent(url);
+  }
+
   return this._userAgent;
 };
 
@@ -381,7 +385,7 @@ Crawler.prototype._downloadUrl = function (url, followRedirect) {
     url: url,
     forever: true,
     headers: {
-      "User-Agent": this.getUserAgent()
+      "User-Agent": this.getUserAgent(url)
     },
     encoding: null,
     followRedirect: Boolean(followRedirect),
@@ -422,7 +426,7 @@ Crawler.prototype._downloadAndCheckRobots = function (url) {
         isAllowed;
 
     robots = robotsParser(self._getRobotsUrl(url), robotsTxt);
-    isAllowed = robots.isAllowed(url, self.getUserAgent());
+    isAllowed = robots.isAllowed(url, self.getUserAgent(url));
 
     if (!isAllowed) {
       return Promise.reject(new error.RobotsNotAllowedError("The URL is " +

--- a/test/Crawler.spec.js
+++ b/test/Crawler.spec.js
@@ -198,6 +198,22 @@ describe("Crawler", function () {
         userAgent: "mybot/1.1"
       }).getUserAgent()).to.equal("mybot/1.1");
     });
+
+    it("will accept a function as a user agent", function () {
+      expect(new Crawler({
+        userAgent: () => "mybot/1.1"
+      }).getUserAgent()).to.equal("mybot/1.1");
+
+      expect(new Crawler({
+        userAgent: (url) => {
+          if (url === 'http://www.example.com/some/random/page') {
+            return 'url specific user agent';
+          }
+
+          return "mybot/1.1";
+        }
+      }).getUserAgent()).to.equal("mybot/1.1");
+    });
   });
 
   describe("#start", function () {


### PR DESCRIPTION
Some websites do not work with certain user agent settings. For example,
there is a website that tries to set cookies if it sees 'Mozilla' in the
user agent. If it cannot set the cookies, then the website refuses to
render any pages. That same website will render pages to the cURL user
agent without problem.